### PR TITLE
Add setting display name and avatar feature

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,20 +1,50 @@
+# port that this service runs on in the docker container
 APP_PORT="3000"
+
+# made up secret you set in the webhook_configs url of a reciever that alertmanager
+# uses when making making HTTP POSTS to this service receivers:
+#  - name: 'myreceiver'
+#    webhook_configs:
+#    - url: 'https://my-matrix-alertmanager.tld/alerts?secret=veryverysecretkeyhere'
 APP_ALERTMANAGER_SECRET="<secret key for the webhook events>"
-MATRIX_HOMESERVER_URL="https://homeserver.tld"
+
+# ----------------------------------------------------------------------------
+#                  matrix homeserver connection info
+# ----------------------------------------------------------------------------
+
+# url of your matrix homeserver, commonly synapse
+MATRIX_HOMESERVER_URL="https://matrix.myhomeserver.tld"
+
 # The rooms to send alerts to, separated by a |
 # Each entry contains the receiver name (from alertmanager) and the
 # internal id (not the public alias) of the Matrix channel to forward to.
+#
+# we may change this down the line because it's ugly :) Perhaps json string?
 MATRIX_ROOMS="receiver1/!abcdefgh:homeserver.tld|receiver2/!qwerty:homeserver.tld"
+
+# "access token" that matrix expects during registration of this bot (also called
+# an appservice). In your registration.yaml that you provide to your homeserver, such as synapse, you will need to provide
+# this token as the as_token
 MATRIX_TOKEN="<token from the alertmanager user on matrix>"
-MATRIX_USER="@alertmanager:homeserver.tld"
+
+# user to use for this bot on your matrix homeserver
+MATRIX_USER="@alertmanager:matrix.myhomeserver.tld"
+
+# optional mxc:// or http:// or https:// URL to use for this bot's avatar photo
+MATRIX_AVATAR="mxc://"
+
 # Set this to 1 to make firing alerts do a `@room` mention.
-# NOTE! Bot should also have enough power in the room for this to be useful.
-MENTION_ROOM="0"
+# ⚠️ NOTE! Bot should also have enough power in the room for this to be useful.
+MENTION_ROOM="true"
 
-# set to enable Grafana links
-#GRAFANA_URL=https://grafana.example.com
+# TODO: check to see if this work?
+#
+# comment to disable Grafana links
+GRAFANA_URL="https://grafana.example.com"
+
 # grafana data source
-#GRAFANA_DATASOURCE=default
+# comment to disable Grafana links
+GRAFANA_DATASOURCE="default"
 
-# set to enable silence link
-#ALERTMANAGER_URL=https://alertmanager.example.com
+# comment to disable silence link
+ALERTMANAGER_URL="https://alertmanager.example.com"

--- a/.env.default
+++ b/.env.default
@@ -30,8 +30,11 @@ MATRIX_TOKEN="<token from the alertmanager user on matrix>"
 # user to use for this bot on your matrix homeserver
 MATRIX_USER="@alertmanager:matrix.myhomeserver.tld"
 
-# optional mxc:// or http:// or https:// URL to use for this bot's avatar photo
+# optional mxc:// URL to use for this bot's avatar photo
 MATRIX_AVATAR="mxc://"
+
+# optional display name this bot
+MATRIX_DISPLAY_NAME="Alertmanager Bot"
 
 # Set this to 1 to make firing alerts do a `@room` mention.
 # ⚠️ NOTE! Bot should also have enough power in the room for this to be useful.

--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,6 @@
-### After July 10 2024
-
-All changes are done by Open Engineering and Jesse Hitch
-
-### Prior to July 10 2024, all code is MIT copyright J. Robinson
-
 MIT License
 
+Copyright (c) 2024 Jesse Hitch
 Copyright (c) 2018 Jason Robinson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A bot to receive Prometheus Alertmanager webhook events and forward them to chos
 
 ## Running the bot in a Docker container
 
-We host a docker image that builds nightly here: [jessebot/matrix-alertmanager-bot](https://hub.docker.com/repository/docker/jessebot/matrix-alertmanager-bot). Checkout out [`.env.default`](./.env.default) for the possible env vars to pass in.
+We host a docker image that builds nightly here: [jessebot/matrix-alertmanager-bot](https://hub.docker.com/repository/docker/jessebot/matrix-alertmanager-bot). Nightly builds are tagged with `main`. Checkout out [`.env.default`](./.env.default) for the possible env vars to pass in.
 
 ## Registering the Application Service with matrix
 Matrix has a concept of [application services](https://spec.matrix.org/v1.11/application-service-api/) (often called an appservice), for bot services/users. To register this bot as an application service, you need to create a registration yaml file, such as `alertmanager.yaml` that's accessible locally to your matrix homeserver (such as synapse), and it should have the following contents:

--- a/README.md
+++ b/README.md
@@ -13,32 +13,23 @@ A bot to receive Prometheus Alertmanager webhook events and forward them to chos
 
 </details>
 
-Main features:
+### Main features
 
-* Uses pre-created Matrix user to send alerts using token auth.
-* Configurable room per alert receiver.
-* Automatic joining of configured rooms. Private rooms require an invite.
-* Secret key authentication with Alertmanager.
-* HTML formatted messages.
+* Uses pre-created Matrix user to send alerts using token auth
+  * you can also use an appserver to register a new user
+* Configurable room per alert receiver
+* Automatic joining of configured rooms. Private rooms require an invite
+* Secret key authentication with Alertmanager
+* HTML formatted messages
 * Optionally mentions `@room` on firing alerts
 
-## How to use
+# How to use
 
-### Configuration
+## Running the bot in a Docker container
 
-Whether running manually or via the Docker image, the configuration is set
-via environment variables. When running manually, copy `.env.default`
-into `.env`, set the values and they will be loaded automatically.
+We host a docker image that builds nightly here: [jessebot/matrix-alertmanager-bot](https://hub.docker.com/repository/docker/jessebot/matrix-alertmanager-bot). Checkout out [`.env.default`](./.env.default) for the possible env vars to pass in.
 
-When using the Docker image, set the environment variables when running
-the container.
-
-### Docker
-
-Still working on this, but when available, it will be here: https://hub.docker.com/r/jessebot/matrix-alertmanager-bot
-
-
-### Alertmanager
+## Setting up Alertmanager
 
 You will need to configure a webhook receiver in Alertmanager. It should looks something like this:
 
@@ -51,7 +42,7 @@ receivers:
 
 The secret key obviously should match the one in the alertmanager configuration.
 
-### Prometheus rules
+## Styling Prometheus rules
 
 Add some styling to your prometheus rules
 
@@ -69,6 +60,10 @@ rules:
 
 NOTE! Currently the bot cannot talk HTTPS, so you need to have a reverse proxy in place to terminate SSL, or use unsecure unencrypted connections.
 
+## Running in Kubernetes
+
+[small-hack/matrix-chart](https://github.com/small-hack/matrix-chart) is a matrix stack for Kubernetes that includes this bot.
+
 ## TODO
 
 * Registering an account instead of having to use an existing account
@@ -79,11 +74,11 @@ NOTE! Currently the bot cannot talk HTTPS, so you need to have a reverse proxy i
 - Express
 - Matrix JS SDK
 
-## Status
+## Authors and Maintainers
 
-This project was originally created by [Jason Robinson](https://jasonrobinson.me) / @jaywink:federator.dev
+This project was originally created by [Jason Robinson](https://jasonrobinson.me) and then it was forked by [beeper/matrix-alertmanager] but they didn't add their own copyright notice, and then I, [@jessebot](https://github.com/jessebot), from [@small-hack](https://github.com/small-hack) forked it as well.
 
-It is now maintained by [small-hack](https://github.com/small-hack) and [@jessebot](https://github.com/jessebot). We're actively cleaning up the security alerts and adding renovatebot to keep it all up to date.
+I've started cleaning up the security alerts and adding plan on renovatebot to keep it all up to date. I'll try to also create some PRs to update the other codebases as well :)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ A bot to receive Prometheus Alertmanager webhook events and forward them to chos
 ### Main features
 
 * Uses pre-created Matrix user to send alerts using token auth
-  * you can also use an appserver to register a new user
+  * you can also use an [application service](https://spec.matrix.org/v1.11/application-service-api/) to register a new user
 * Configurable room per alert receiver
 * Automatic joining of configured rooms. Private rooms require an invite
 * Secret key authentication with Alertmanager
 * HTML formatted messages
 * Optionally mentions `@room` on firing alerts
+* Optionally set the bot user's display name and avatar
 
 # How to use
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-alertmanager",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Prometheus Alertmanager bot for Matrix",
   "main": "src/app.js",
   "scripts": {

--- a/src/client.js
+++ b/src/client.js
@@ -36,9 +36,14 @@ const client = {
             }
         })
 
+        // ensure display name is updated
+        if (process.env.MATRIX_DISPLAY_NAME) {
+            this.connection.setDisplayName(process.env.MATRIX_DISPLAY_NAME);
+        }
+
         // ensure avatar is updated
         if (process.env.MATRIX_AVATAR_URL) {
-            const profile = this.connection.setAvatarUrl(process.env.MATRIX_AVATAR_URL);
+            this.connection.setAvatarUrl(process.env.MATRIX_AVATAR_URL);
         }
     },
     sendAlert: async function(roomId, alert) {

--- a/src/client.js
+++ b/src/client.js
@@ -35,6 +35,11 @@ const client = {
                 await this.ensureInRoom(room[1])
             }
         })
+
+        // ensure avatar is updated
+        if (process.env.MATRIX_AVATAR_URL) {
+            const profile = this.connection.setAvatarUrl(process.env.MATRIX_AVATAR_URL);
+        }
     },
     sendAlert: async function(roomId, alert) {
         await this.ensureInRoom(roomId)


### PR DESCRIPTION
## Description

- adds more comments to the default environment variables in `.env.default`
- adds new env vars:
  ```env
  # optional mxc:// URL to use for this bot's avatar photo
  MATRIX_AVATAR="mxc://"

  # optional display name this bot
  MATRIX_DISPLAY_NAME="Alertmanager Bot"
  ```
- fix licensing to include both copyright properly (was using markdown before)
- add explanation on how to register an application service with matrix