### PR TITLE
Formatting release: use description for summary; allow greater control over HEX codes used for colors of message text; clean up styling and duplicate info

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -53,10 +53,9 @@ GRAFANA_DATASOURCE="default"
 ALERTMANAGER_URL="https://alertmanager.example.com"
 
 # colors for alert message text. These are HEX codes.
-COLOR_CRITICAL="#E41227" # red
-COLOR_ERROR="#FF4507" # orange
-COLOR_WARNING="#FFE608" # yellow
-COLOR_INFO="#1661B8" # blue
-COLOR_DEFAULT="#999999" # grey
-
-
+COLOR_CRITICAL="#ff8d87" # red
+COLOR_ERROR="#f289f9" # orange
+COLOR_WARNING="#f7fb53" # yellow
+COLOR_INFO="#7aa2f7" # blue
+COLOR_RECOVERED="#a8fd57"
+COLOR_DEFAULT="#585858" # grey

--- a/.env.default
+++ b/.env.default
@@ -53,9 +53,9 @@ GRAFANA_DATASOURCE="default"
 ALERTMANAGER_URL="https://alertmanager.example.com"
 
 # colors for alert message text. These are HEX codes.
-COLOR_CRITICAL="#ff8d87" # red
+COLOR_CRITICAL="#f2748a" # red
 COLOR_ERROR="#f289f9" # orange
-COLOR_WARNING="#f7fb53" # yellow
+COLOR_WARNING="#fdcd36" # yellow
 COLOR_INFO="#7aa2f7" # blue
 COLOR_RECOVERED="#a8fd57"
 COLOR_DEFAULT="#585858" # grey

--- a/.env.default
+++ b/.env.default
@@ -51,3 +51,12 @@ GRAFANA_DATASOURCE="default"
 
 # comment to disable silence link
 ALERTMANAGER_URL="https://alertmanager.example.com"
+
+# colors for alert message text. These are HEX codes.
+COLOR_CRITICAL="#E41227" # red
+COLOR_ERROR="#FF4507" # orange
+COLOR_WARNING="#FFE608" # yellow
+COLOR_INFO="#1661B8" # blue
+COLOR_DEFAULT="#999999" # grey
+
+

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ A bot to receive Prometheus Alertmanager webhook events and forward them to chos
 * Configurable room per alert receiver
 * Automatic joining of configured rooms. Private rooms require an invite
 * Secret key authentication with Alertmanager
-* HTML formatted messages
+* 🎨 HTML formatted messages
+  * You can now choose the colors for severity too!
 * Optionally mentions `@room` on firing alerts
 * Optionally set the bot user's display name and avatar
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A bot to receive Prometheus Alertmanager webhook events and forward them to chos
 * Automatic joining of configured rooms. Private rooms require an invite
 * Secret key authentication with Alertmanager
 * 🎨 HTML formatted messages
-  * You can now choose the colors for severity too!
+  * You can now choose the text colors for each severity too!
 * Optionally mentions `@room` on firing alerts
 * Optionally set the bot user's display name and avatar
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matrix-alertmanager",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matrix-alertmanager",
-      "version": "0.11.2",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-alertmanager",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Prometheus Alertmanager bot for Matrix",
   "main": "src/app.js",
   "scripts": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,7 +80,7 @@ const utils = {
 	    } else {
 		let resolved_color = "#a8fd57"
 	    }
-            parts.push('<summary><font color=\"' + resolved_color + '\"><b>RESOLVED</b>: ' summary + env + '</font></summary>')
+            parts.push('<summary><font color=\"' + resolved_color + '\"><b>RESOLVED</b>: ' + summary + env + '</font></summary>')
         } else {
             parts.push('<summary>' + data.status.toUpperCase() + ': ' + summary + env + '</summary>')
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,7 +45,7 @@ const utils = {
 		        if (process.env.COLOR_CRITICAL) {
 			    return process.env.COLOR_CRITICAL;
 			} else {
-                            return '#ff8d87'; // red
+                            return '#f2748a'; // red
 			}
                     case 'error':
 		        if (process.env.COLOR_ERROR) {
@@ -57,7 +57,7 @@ const utils = {
 		        if (process.env.COLOR_WARNING) {
 			    return process.env.COLOR_WARNING;
 			} else {
-                            return '#f7fb53'; // yellow
+                            return '#fdcd36'; // yellow
 			}
                     case 'info':
 		        if (process.env.COLOR_INFO) {
@@ -69,7 +69,7 @@ const utils = {
 		        if (process.env.COLOR_DEFAULT) {
 			    return process.env.COLOR_DEFAULT;
 			} else {
-                            return '#585858'; // grey
+                            return '#7aa2f7'; // grey
 			}
                 }
             })(data.labels.severity);
@@ -80,7 +80,7 @@ const utils = {
 	    } else {
 		let resolved_color = "#a8fd57"
 	    }
-            parts.push('<summary><strong><font color=\"' + resolved_color + '\">RESOLVED</strong>: ' + summary + env + '</font></summary>')
+            parts.push('<summary><strong><font color=\"' + resolved_color + '\">RESOLVED</strong>: ' summary + env + '</font></summary>')
         } else {
             parts.push('<summary>' + data.status.toUpperCase() + ': ' + summary + env + '</summary>')
         }
@@ -88,7 +88,7 @@ const utils = {
         parts.push('<br />\n')
 
         Object.keys(data.labels).forEach((label) => {
-            parts.push('<b>' + label + '</b>: ' + data.labels[label] + '<br>\n')
+            parts.push('<b><font color=\"#bdd8ff\">' + label + '</font></b>: ' + data.labels[label] + '<br>\n')
         });
 
         parts.push('<br />\n')

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,8 +25,8 @@ const utils = {
         let parts = []
 
         let summary = ""
-        if (data.annotations.hasOwnProperty("summary")) {
-            summary = data.annotations.summary;
+        if (data.annotations.hasOwnProperty("description")) {
+            summary = data.annotations.description.split('.')[0];
         } else if (data.labels.hasOwnProperty("alertname")) {
             summary = data.labels.alertname;
         }
@@ -42,15 +42,35 @@ const utils = {
             let color = (function (severity) {
                 switch (severity) {
                     case 'critical':
-                        return '#E41227'; // red
+		        if (process.env.COLOR_CRITICAL) {
+			    return process.env.COLOR_CRITICAL;
+			} else {
+                            return '#E41227'; // red
+			}
                     case 'error':
-                        return '#FF4507'; // orange
+		        if (process.env.COLOR_ERROR) {
+			    return process.env.COLOR_ERROR;
+			} else {
+                            return '#FF4507'; // orange
+			}
                     case 'warning':
-                        return '#FFE608'; // yellow
+		        if (process.env.COLOR_WARNING) {
+			    return process.env.COLOR_WARNING;
+			} else {
+                            return '#FFE608'; // yellow
+			}
                     case 'info':
-                        return '#1661B8'; // blue
+		        if (process.env.COLOR_INFO) {
+			    return process.env.COLOR_INFO;
+			} else {
+                            return '#1661B8'; // blue
+			}
                     default:
-                        return '#999999'; // grey
+		        if (process.env.COLOR_DEFAULT) {
+			    return process.env.COLOR_DEFAULT;
+			} else {
+                            return '#999999'; // grey
+			}
                 }
             })(data.labels.severity);
             parts.push('<summary><strong><font color=\"' + color + '\">FIRING: ' + summary + env + '</font></strong></summary>')

--- a/src/utils.js
+++ b/src/utils.js
@@ -89,7 +89,7 @@ const utils = {
         parts.push('<br />\n')
 
         Object.keys(data.annotations).forEach((annotation) => {
-            if (annotation != "summary" && !annotation.startsWith("logs_")) {
+            if (annotation != "summary" && annotation != "runbook_url" && !annotation.startsWith("logs_")) {
                 parts.push('<b>' + annotation + '</b>: ' + data.annotations[annotation] + '<br>\n')
             }
         })

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,7 +80,7 @@ const utils = {
 	    } else {
 		let resolved_color = "#a8fd57"
 	    }
-            parts.push('<summary><strong><font color=\"' + resolved_color + '\">RESOLVED</strong>: ' summary + env + '</font></summary>')
+            parts.push('<summary><strong><font color=\"' + resolved_color + '\">RESOLVED</strong>: ' + summary + env + '</font></summary>')
         } else {
             parts.push('<summary>' + data.status.toUpperCase() + ': ' + summary + env + '</summary>')
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,37 +45,42 @@ const utils = {
 		        if (process.env.COLOR_CRITICAL) {
 			    return process.env.COLOR_CRITICAL;
 			} else {
-                            return '#E41227'; // red
+                            return '#ff8d87'; // red
 			}
                     case 'error':
 		        if (process.env.COLOR_ERROR) {
 			    return process.env.COLOR_ERROR;
 			} else {
-                            return '#FF4507'; // orange
+                            return '#f289f9'; // magenta
 			}
                     case 'warning':
 		        if (process.env.COLOR_WARNING) {
 			    return process.env.COLOR_WARNING;
 			} else {
-                            return '#FFE608'; // yellow
+                            return '#f7fb53'; // yellow
 			}
                     case 'info':
 		        if (process.env.COLOR_INFO) {
 			    return process.env.COLOR_INFO;
 			} else {
-                            return '#1661B8'; // blue
+                            return '#7aa2f7'; // blue
 			}
                     default:
 		        if (process.env.COLOR_DEFAULT) {
 			    return process.env.COLOR_DEFAULT;
 			} else {
-                            return '#999999'; // grey
+                            return '#585858'; // grey
 			}
                 }
             })(data.labels.severity);
-            parts.push('<summary><strong><font color=\"' + color + '\">FIRING: ' + summary + env + '</font></strong></summary>')
+            parts.push('<summary><strong><font color=\"' + color + '\">FIRING</strong>: ' + summary + env + '</font></summary>')
         } else if (data.status === 'resolved') {
-            parts.push('<summary><strong><font color=\"#33CC33\">RESOLVED: ' + summary + env + '</font></strong></summary>')
+	    if (process.env.COLOR_RECOVERED) {
+		let resolved_color = process.env.COLOR_RECOVERED
+	    } else {
+		let resolved_color = "#a8fd57"
+	    }
+            parts.push('<summary><strong><font color=\"' + resolved_color + '\">RESOLVED</strong>: ' + summary + env + '</font></summary>')
         } else {
             parts.push('<summary>' + data.status.toUpperCase() + ': ' + summary + env + '</summary>')
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,14 +73,14 @@ const utils = {
 			}
                 }
             })(data.labels.severity);
-            parts.push('<summary><strong><font color=\"' + color + '\">FIRING</strong>: ' + summary + env + '</font></summary>')
+            parts.push('<summary><font color=\"' + color + '\"><b>FIRING</b>: ' + summary + env + '</font></summary>')
         } else if (data.status === 'resolved') {
 	    if (process.env.COLOR_RECOVERED) {
 		let resolved_color = process.env.COLOR_RECOVERED
 	    } else {
 		let resolved_color = "#a8fd57"
 	    }
-            parts.push('<summary><strong><font color=\"' + resolved_color + '\">RESOLVED</strong>: ' + summary + env + '</font></summary>')
+            parts.push('<summary><font color=\"' + resolved_color + '\"><b>RESOLVED</b>: ' summary + env + '</font></summary>')
         } else {
             parts.push('<summary>' + data.status.toUpperCase() + ': ' + summary + env + '</summary>')
         }
@@ -88,14 +88,14 @@ const utils = {
         parts.push('<br />\n')
 
         Object.keys(data.labels).forEach((label) => {
-            parts.push('<b><font color=\"#bdd8ff\">' + label + '</font></b>: ' + data.labels[label] + '<br>\n')
+            parts.push('<font color=\"#bdd8ff\"><b>' + label + '</b></font>: ' + data.labels[label] + '<br>\n')
         });
 
         parts.push('<br />\n')
 
         Object.keys(data.annotations).forEach((annotation) => {
             if (annotation != "summary" && annotation != "runbook_url" && !annotation.startsWith("logs_")) {
-                parts.push('<b>' + annotation + '</b>: ' + data.annotations[annotation] + '<br>\n')
+                parts.push('<font color=\"#bdd8ff\"><b>' + annotation + '</b></font>: ' + data.annotations[annotation] + '<br>\n')
             }
         })
         parts.push('</details>')


### PR DESCRIPTION
## New env variables

```env
# colors for alert message text. These are HEX codes.
COLOR_CRITICAL="#ff8d87"  # red
COLOR_ERROR="#f289f9"  # orange
COLOR_WARNING="#f7fb53"  # yellow
COLOR_INFO="#7aa2f7"  # blue
COLOR_RECOVERED="#a8fd57"  # green
COLOR_DEFAULT="#585858"  # grey
```

This release also includes a bit more formatting of the alert text to make the main attribute bold and the rest normal weight, as well as making labels a slightly different color than the values in the expanded collapsible. We also removed the runbook url in the expanded collapsible, because it's already linked with the 🏃 emoji quick links. Finally, we now use the alert's description rather than summary so you can easily see what resource is alerting, instead of the a broad overview of "job failed". Now you'll know which job failed at a glance :)